### PR TITLE
01 use viem multicall

### DIFF
--- a/src/hooks/useVaultData.ts
+++ b/src/hooks/useVaultData.ts
@@ -9,7 +9,7 @@ import { roundToDecimals } from "@/util";
 
 interface VaultParams {
   readonly addressVault: string,
-  readonly addressUser: `0x${string}`,
+  readonly addressUser: `0x${string}` | undefined,
   readonly enabled: boolean,
 }
 interface VaultInfo {
@@ -47,6 +47,8 @@ const useVaultData = ({ addressVault, addressUser, enabled }: VaultParams): Vaul
           address: addressVault as `0x${string}`,
           abi: metaMorphoAbi,
         } as const;
+
+        if (!addressUser) throw "Address is undefined";
 
         const call1results = await publicClient.multicall({
           contracts: [

--- a/src/hooks/useVaultData.ts
+++ b/src/hooks/useVaultData.ts
@@ -3,7 +3,7 @@
 import metaMorphoAbi from "../abi/metaMorpho";
 import ERC20Abi from "../abi/ERC20";
 import { publicClient } from '../infra/clients'
-import { formatUnits, getContract } from "viem";
+import { formatUnits } from "viem";
 import { useEffect, useRef, useState } from "react";
 import { roundToDecimals } from "@/util";
 


### PR DESCRIPTION
Improves the query call time for vault data.
Runtime reduced from roughly 2.5 sec to 1.2 sec for my Tenderly connection.

Before:
![Snimka zaslona 2024-08-06 195922](https://github.com/user-attachments/assets/1b48e7f7-5d3a-449a-ba99-b6f3ffdcbda2)
After:
![Snimka zaslona 2024-08-06 202849](https://github.com/user-attachments/assets/e3bbc47a-34f0-4037-bd22-ec6b419a04f5)
